### PR TITLE
Add admin ability to select item image during creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
 gem 'turbolinks'
+gem 'jquery-turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -190,6 +193,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.0)
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   launchy
   material_icons
   pg (~> 0.15)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require jquery.turbolinks
 //= require_tree .
 
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -224,6 +224,12 @@ a.brand-logo {
 #item-form label {
   color: black;
 }
+.dropdown-content li span {
+  color: white;
+}
+.dropdown-content li span:hover {
+  color: black;
+}
 
 #required-field {
   font-family: "Special Elite";

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -6,6 +6,9 @@
     <%= f.label :title, class: "form-text" %>
     <%= f.text_field :title %>
 
+    <%= f.label :image, class: "form-text" %>
+    <%= f.text_field :image %>
+
     <%= f.label :description, class: "form-text" %>
     <%= f.text_field :description %>
 

--- a/test/integration/admin_creates_new_item_test.rb
+++ b/test/integration/admin_creates_new_item_test.rb
@@ -5,7 +5,7 @@ class AdminCreatesNewItemTest < ActionDispatch::IntegrationTest
     Category.create(title: "Books")
     admin = create_admin
     login(admin)
-    image_path =
+    default_image =
       "http://www.vbdl.org/wp-content/uploads/2015/09/cartoon-zombies-373177.jpg"
     visit admin_dashboard_path
     click_on "Create New Item"
@@ -19,7 +19,34 @@ class AdminCreatesNewItemTest < ActionDispatch::IntegrationTest
     within "#item-show" do
       assert page.has_content? "Baseball Bat"
       assert page.has_content? "Home run!"
-      assert page.has_css? "img[src=\"#{image_path}\"]"
+      assert page.has_css? "img[src=\"#{default_image}\"]"
+    end
+  end
+
+  test "admin can upload image with new item" do
+    Category.create(title: "Books")
+    admin = create_admin
+    login(admin)
+    default_image =
+      "http://www.vbdl.org/wp-content/uploads/2015/09/cartoon-zombies-373177.jpg"
+    item_image =
+      "http://i465.photobucket.com/albums/rr16/xXswampyXx/BaseballBatNNails3_zps9660d65c.jpg"
+
+    visit admin_dashboard_path
+    click_on "Create New Item"
+    fill_in "Title", with: "Baseball Bat"
+    fill_in "Image", with: item_image
+    fill_in "Description", with: "Home run!"
+    fill_in "Price", with: 20
+    select "Books", from: "item[category_id]"
+    click_on "Submit"
+
+    assert_equal item_path(Item.last), current_path
+    within "#item-show" do
+      assert page.has_content? "Baseball Bat"
+      assert page.has_content? "Home run!"
+      assert page.has_css? "img[src=\"#{item_image}\"]"
+      refute page.has_css? "img[src=\"#{default_image}\"]"
     end
   end
 end


### PR DESCRIPTION
We didn't actually integrate carrier wave, just added the ability to input an HTML string to get the image.